### PR TITLE
比較画面からのbasis入れ替え、表示情報が空のときの表示

### DIFF
--- a/app/src/main/java/honkot/gscheduler/activity/TabActivity.java
+++ b/app/src/main/java/honkot/gscheduler/activity/TabActivity.java
@@ -34,11 +34,6 @@ public class TabActivity extends BaseActivity implements
         recordListFragment.setOnItemClickListener(new RecordListFragment.OnItemClickListener() {
             @Override
             public void onItemClick(CompareLocale compareLocale) {
-                FragmentPagerAdapter adapter =
-                        (FragmentPagerAdapter) binding.pager.getAdapter();
-                CompareListFragment fragment =
-                        (CompareListFragment) adapter.getItem(PAGE_COMPARE);
-                fragment.initialize();
                 binding.pager.setCurrentItem(PAGE_COMPARE);
             }
         });
@@ -85,6 +80,20 @@ public class TabActivity extends BaseActivity implements
 
     @Override
     public void onPageSelected(int position) {
+        FragmentPagerAdapter adapter =
+                (FragmentPagerAdapter) binding.pager.getAdapter();
+
+        if (position == PAGE_COMPARE) {
+            // initialize compare page
+            CompareListFragment fragment =
+                    (CompareListFragment) adapter.getItem(PAGE_COMPARE);
+            fragment.initialize();
+
+        } else if (position == PAGE_RECORD_LIST) {
+            RecordListFragment fragment =
+                    (RecordListFragment) adapter.getItem(PAGE_RECORD_LIST);
+            fragment.updateViewIfNeeded();
+        }
     }
 
     @Override

--- a/app/src/main/java/honkot/gscheduler/utils/MyRecAdapter.java
+++ b/app/src/main/java/honkot/gscheduler/utils/MyRecAdapter.java
@@ -50,13 +50,20 @@ public class MyRecAdapter extends RecyclerView.Adapter<MyRecAdapter.MyViewHolder
     }
 
     public void switchBasis(CompareLocale_Selector newSelector, CompareLocale newBasis) {
+        innerSwitchBasis(newSelector, newBasis, false);
+    }
+
+    public void switchBasisWithClearCash(CompareLocale_Selector newSelector, CompareLocale newBasis) {
+        innerSwitchBasis(newSelector, newBasis, true);
+    }
+
+    private void innerSwitchBasis(CompareLocale_Selector newSelector, CompareLocale newBasis, boolean cashClear) {
         for (MyViewHolder holder : mViewHolders) {
             holder.compareLocale.setBasis(holder.compareLocale.equals(newBasis));
-            Debug.Log("p:" + holder.position + ", f:" + holder.compareLocale.isBasis());
             holder.binding.setCompareLocale(holder.compareLocale);
         }
         // mDataCashはそのまま使いたいので、selectorだけ変更するようにする
-        setSelector(newSelector, false);
+        setSelector(newSelector, cashClear);
     }
 
     private void setSelector(CompareLocale_Selector selector, boolean needCashClean) {

--- a/app/src/main/res/layout/fragment_compare_list.xml
+++ b/app/src/main/res/layout/fragment_compare_list.xml
@@ -13,7 +13,13 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
+        <include
+            android:id="@+id/emptyView"
+            layout="@layout/view_empty_locale"
+            android:visibility="gone" />
+
         <LinearLayout
+            android:id="@+id/mainView"
             android:layout_width="match_parent"
             android:layout_height="250dp"
             android:layout_alignParentLeft="true"

--- a/app/src/main/res/layout/fragment_record_list.xml
+++ b/app/src/main/res/layout/fragment_record_list.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
-    <android.support.v7.widget.RecyclerView
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:id="@+id/recyclerView" />
+        android:layout_height="match_parent">
+        <include
+            android:id="@+id/emptyView"
+            layout="@layout/view_empty_locale"
+            android:visibility="gone" />
+        <android.support.v7.widget.RecyclerView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/recyclerView" />
+    </LinearLayout>
 </layout>
 

--- a/app/src/main/res/layout/view_empty_locale.xml
+++ b/app/src/main/res/layout/view_empty_locale.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <RelativeLayout
+        android:id="@+id/emptyViewRoot"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <Button
+            android:id="@+id/addFirstLocaleButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/view_empty_locale_button"
+            android:layout_centerVertical="true"
+            android:layout_centerHorizontal="true"/>
+    </RelativeLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,8 +8,8 @@
   <string name="leftArrow">＜</string>
   <string name="rightArrow">＞</string>
   <string-array name="tab_titles">
-      <item>Time Now</item>
       <item>Set Time</item>
+      <item>Time Now</item>
   </string-array>
   <string name="title_bar">DONE</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,8 @@
       <item>Time Now</item>
   </string-array>
   <string name="title_bar">DONE</string>
+
+  <string name="view_empty_locale_button">Add First Locale Here!</string>
+  <string name="compare_fragment_toast_empty_record">Add any locale first</string>
+  <string name="compare_fragment_toast_tap_locale">Tap any locale for basis locale</string>
 </resources>


### PR DESCRIPTION
いくつかの対応
・タブ名が逆だったので入れ替えた
・比較画面からbasisを入れ替えるよう修正（お試し）
・表示する情報がない場合は追加画面へ遷移するよう修正（お試し）