### PR TITLE
bugfix for down when the user does first boot #72

### DIFF
--- a/app/src/main/java/jp/lovesalmon/globalclock/activity/TabActivity.java
+++ b/app/src/main/java/jp/lovesalmon/globalclock/activity/TabActivity.java
@@ -210,7 +210,7 @@ private final static String PREF = "pref";
             String id = (String)map.get("id");
 
             if (defaultIds.contains(id)) {
-                CompareLocale locale = new CompareLocale(this);
+                CompareLocale locale = CompareLocale.getInstance();
                 locale.setLocationName(name);
                 locale.setGmtId(id);
                 ZonedDateTime newOne = locale.getZonedDateTime().withZoneSameInstant(ZoneId.of(gmt));

--- a/app/src/main/java/jp/lovesalmon/globalclock/fragment/SearchListFragment.java
+++ b/app/src/main/java/jp/lovesalmon/globalclock/fragment/SearchListFragment.java
@@ -167,7 +167,7 @@ public class SearchListFragment extends Fragment {
         public void onItemClick(AdapterView<?> adapterView, View view, int position, long id) {
             // set locale.
             TmpTimeZone tmpTimeZone = getItem(position);
-            CompareLocale locale = new CompareLocale(getActivity());
+            CompareLocale locale = CompareLocale.getInstance();
             locale.setLocationName(tmpTimeZone.getName());
             locale.setGmtId(tmpTimeZone.getLocaleId());
             ZonedDateTime newOne = locale.getZonedDateTime().withZoneSameInstant(ZoneId.of(tmpTimeZone.getGmt()));

--- a/app/src/main/java/jp/lovesalmon/globalclock/model/CompareLocale.java
+++ b/app/src/main/java/jp/lovesalmon/globalclock/model/CompareLocale.java
@@ -1,6 +1,5 @@
 package jp.lovesalmon.globalclock.model;
 
-import android.content.Context;
 import android.provider.BaseColumns;
 import android.support.annotation.NonNull;
 
@@ -12,10 +11,6 @@ import com.github.gfx.android.orma.annotation.Table;
 
 import org.threeten.bp.ZoneId;
 import org.threeten.bp.ZonedDateTime;
-
-import java.util.TimeZone;
-
-import jp.lovesalmon.globalclock.utils.AdapterGenerater;
 
 @Table
 public class CompareLocale implements ListBindingInterface {
@@ -46,18 +41,15 @@ public class CompareLocale implements ListBindingInterface {
 
     private int offsetMins = 0;
 
-    public CompareLocale() {
-
-    }
-
-    public CompareLocale(Context context) {
-        this.basis = false;
-        String gmt = TimeZone.getDefault().getDisplayName(false, TimeZone.SHORT);
-        this.zonedDateTime = ZonedDateTime.now(ZoneId.of(gmt))
-                    .withSecond(0).withNano(0);
-        this.gmtId = AdapterGenerater.getIdByGMT(context, gmt);
-        this.taskName = "";
-        this.locationName = gmtId;
+    public static CompareLocale getInstance() {
+        CompareLocale newInstance = new CompareLocale();
+        newInstance.basis = false;
+        newInstance.zonedDateTime = ZonedDateTime.now(ZoneId.systemDefault())
+                .withSecond(0).withNano(0);
+        newInstance.gmtId = ZoneId.systemDefault().getId();
+        newInstance.taskName = "";
+        newInstance.locationName = newInstance.gmtId;
+        return newInstance;
     }
 
     @Getter


### PR DESCRIPTION
Close #72 

原因：DefaultTimeZoneの取得方法が少し違った
　　　その影響でTimeZoneクラスも知らないIDが渡っていたので死んでいた。